### PR TITLE
fix negative number support

### DIFF
--- a/lib/Convert/Bencode.pm
+++ b/lib/Convert/Bencode.pm
@@ -102,7 +102,7 @@ sub bencode {
 		$line .= 'e';
 		return $line;
 	}
-	if($item =~ /^\d+$/) {
+	if($item =~ /^(?:0|-?[1-9]\d*)$/) {
 		$line = 'i';
 		$line .= $item;
 		$line .= 'e';


### PR DESCRIPTION
there is a bug with negative numbers in Convert::Bencode - this patch add more complicated support for numbers. 

negative numbers, like -1 sould be converted to number "i-1e", not to string "2:-1" like module does.
